### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: [test, lint]
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -140,4 +142,3 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-


### PR DESCRIPTION
Potential fix for [https://github.com/Lumina-Enterprise-Solutions/prism-common-libs/security/code-scanning/4](https://github.com/Lumina-Enterprise-Solutions/prism-common-libs/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow or the specific job (`Build`) to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the `Build` job only requires read access to the repository contents, we will set `contents: read` as the permission. This ensures the job has the minimal permissions required to complete its tasks.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `Build` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
