### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Lumina-Enterprise-Solutions/prism-common-libs/security/code-scanning/3](https://github.com/Lumina-Enterprise-Solutions/prism-common-libs/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `security` job in the workflow file. Since the job only requires access to the repository contents for scanning purposes, we can set `contents: read` as the minimal permission. This change ensures that the `GITHUB_TOKEN` used in the job has restricted access, reducing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
