### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Lumina-Enterprise-Solutions/prism-common-libs/security/code-scanning/2](https://github.com/Lumina-Enterprise-Solutions/prism-common-libs/security/code-scanning/2)

To fix the issue, add a `permissions` block to the `lint` job. Since the job only needs to read the repository contents to perform linting, the minimal required permission is `contents: read`. This change ensures that the job does not inherit unnecessary permissions from the repository or workflow defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
